### PR TITLE
Fix MongoDB link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For specific development details of each component, including configuration, see
 
 ### Prerequisites
 
-First, ensure you have [Node.js LTS](https://nodejs.org/), [Yarn](https://yarnpkg.com/), and MongoDB[https://www.mongodb.com/download-center/community] installed.  The CDS Authoring Tool is tested using MongoDB 3.4.x, but later versions are expected to work.
+First, ensure you have [Node.js LTS](https://nodejs.org/), [Yarn](https://yarnpkg.com/), and [MongoDB](https://www.mongodb.com/download-center/community) installed.  The CDS Authoring Tool is tested using MongoDB 3.4.x, but later versions are expected to work.
 
 ### Install Node Foreman
 


### PR DESCRIPTION
Fixes the markdown for the MongoDB link in the [`Prerequisites section of the README`](https://github.com/AHRQ-CDS/AHRQ-CDS-Connect-Authoring-Tool#prerequisites)

**Before:**
![Screen Shot 2020-04-17 at 8 24 25 AM](https://user-images.githubusercontent.com/41651655/79569205-349e0b80-8085-11ea-81ab-88669e2e9752.png)

**After:**
![Screen Shot 2020-04-17 at 8 31 05 AM](https://user-images.githubusercontent.com/41651655/79569563-cefe4f00-8085-11ea-90a9-69d5f0c4748d.png)
